### PR TITLE
Fix typo in Russian error message

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -159,7 +159,7 @@ def create_booking(email: str, author: str, title: str):
 
     if flag_1 == True:
         print('Пользователя с таким email не существует')    
-        return response(404, 'Пользотель с таким email не найден')
+        return response(404, 'Пользователь с таким email не найден')
     
     flag_1 = True
 


### PR DESCRIPTION
## Summary
- fix typo in user not found error message

## Testing
- `pytest -q` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68461ad45cc08332be56582d03d1b070